### PR TITLE
feat(makefile): Auto-detect available compose tool in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ CONTAINER_IMAGE := dcm-placement-api
 CONTAINER_TAG := latest
 COMPOSE_FILE := $(realpath deploy/podman/compose.yaml)
 
+COMPOSE ?= $(shell command -v podman-compose >/dev/null 2>&1 && echo podman-compose || \
+	(command -v docker-compose >/dev/null 2>&1 && echo docker-compose || \
+	(echo "docker compose")))
+
 # Build the application
 build:
 	go build -o bin/dcm-placement-api ./cmd/dcm-placement-api
@@ -27,15 +31,15 @@ clean:
 
 # Build container image
 container-build:
-	podman build -t $(CONTAINER_IMAGE):$(CONTAINER_TAG) .
+	$(COMPOSE) build -t $(CONTAINER_IMAGE):$(CONTAINER_TAG) .
 
 # Run compose up
 compose-up:
-	podman-compose -f $(COMPOSE_FILE) up -d
+	$(COMPOSE) -f $(COMPOSE_FILE) up -d
 
 # Run compose down
 compose-down:
-	podman-compose -f $(COMPOSE_FILE) down
+	$(COMPOSE) -f $(COMPOSE_FILE) down
 
 # Format code
 fmt:

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,11 @@ CONTAINER_IMAGE := dcm-placement-api
 CONTAINER_TAG := latest
 COMPOSE_FILE := $(realpath deploy/podman/compose.yaml)
 
+CONTAINER_RUNTIME ?= $(shell command -v podman >/dev/null 2>&1 && echo podman || echo docker)
+
 COMPOSE ?= $(shell command -v podman-compose >/dev/null 2>&1 && echo podman-compose || \
 	(command -v docker-compose >/dev/null 2>&1 && echo docker-compose || \
-	(echo "docker compose")))
+	(docker compose version >/dev/null 2>&1 && echo "docker compose" || echo "")))
 
 # Build the application
 build:
@@ -31,15 +33,15 @@ clean:
 
 # Build container image
 container-build:
-	$(COMPOSE) build -t $(CONTAINER_IMAGE):$(CONTAINER_TAG) .
+	@$(CONTAINER_RUNTIME) build -t $(CONTAINER_IMAGE):$(CONTAINER_TAG) .
 
 # Run compose up
 compose-up:
-	$(COMPOSE) -f $(COMPOSE_FILE) up -d
+	@$(COMPOSE) -f $(COMPOSE_FILE) up -d
 
 # Run compose down
 compose-down:
-	$(COMPOSE) -f $(COMPOSE_FILE) down
+	@$(COMPOSE) -f $(COMPOSE_FILE) down
 
 # Format code
 fmt:


### PR DESCRIPTION
### Description

- Support podman-compose, docker-compose, and docker compose by checking which tool is available. This improves portability.

## Summary by Sourcery

Auto-detect and use the available compose tool in the Makefile for container build and compose commands to improve portability.

Enhancements:
- Introduce a COMPOSE variable that selects podman-compose, docker-compose, or docker compose based on availability.
- Update container build and compose targets to rely on the selected compose tool instead of hardcoding podman-compose.